### PR TITLE
Use hook rather than preexec.

### DIFF
--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -4,6 +4,9 @@ PLUGIN_DIR=$(dirname $0)
 #export ZSH_PLUGINS_ALIAS_TIPS_EXCLUDES="_ c"
 #export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=1
 
-preexec() {
+_alias-tips_preexec () {
   alias | ${PLUGIN_DIR}/alias-tips $*
 }
+
+autoload -Uz add-zsh-hook
+add-zsh-hook preexec _alias-tips_preexec


### PR DESCRIPTION
This allows alias-tips to cooperate with other plugins that want to use `preexec`.