### PR TITLE
Don't globally set PLUGIN_DIR.

### DIFF
--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -1,11 +1,11 @@
-PLUGIN_DIR=$(dirname $0)
+_alias_tips__PLUGIN_DIR=$(dirname $0)
 
 #export ZSH_PLUGINS_ALIAS_TIPS_TEXT="💡 Alias tip: "
 #export ZSH_PLUGINS_ALIAS_TIPS_EXCLUDES="_ c"
 #export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=1
 
 _alias-tips_preexec () {
-  alias | ${PLUGIN_DIR}/alias-tips $*
+  alias | ${_alias_tips__PLUGIN_DIR}/alias-tips $*
 }
 
 autoload -Uz add-zsh-hook

--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -4,9 +4,9 @@ _alias_tips__PLUGIN_DIR=$(dirname $0)
 #export ZSH_PLUGINS_ALIAS_TIPS_EXCLUDES="_ c"
 #export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=1
 
-_alias-tips_preexec () {
+_alias_tips__preexec () {
   alias | ${_alias_tips__PLUGIN_DIR}/alias-tips $*
 }
 
 autoload -Uz add-zsh-hook
-add-zsh-hook preexec _alias-tips_preexec
+add-zsh-hook preexec _alias_tips__preexec


### PR DESCRIPTION
This can't be a `local`, though, as zsh variables aren't lexical.

This is based on #7, since there is otherwise a trivial conflict.
