### PR TITLE
Check git aliases first if git exists

### DIFF
--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -6,15 +6,15 @@ _alias_tips__PLUGIN_DIR=$(dirname $0)
 
 _alias_tips__preexec () {
   if hash git 2> /dev/null; then
-    \git alias | \
+    git_aliases=$(\git alias | \
       sed 's/^/git /' | \
       sed 's/ = \([^!]\)/ = git \1/' | \
-      sed 's/ = !/ = /' | \
-      ${_alias_tips__PLUGIN_DIR}/alias-tips $* && \
-      return
+      sed 's/ = !/ = /')
   fi
 
-  alias | ${_alias_tips__PLUGIN_DIR}/alias-tips $*
+  shell_aliases=$(alias)
+
+  echo $git_aliases $shell_aliases | ${_alias_tips__PLUGIN_DIR}/alias-tips $*
 }
 
 autoload -Uz add-zsh-hook

--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -5,6 +5,15 @@ _alias_tips__PLUGIN_DIR=$(dirname $0)
 #export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=1
 
 _alias_tips__preexec () {
+  if hash git 2> /dev/null; then
+    \git alias | \
+      sed 's/^/git /' | \
+      sed 's/ = \([^!]\)/ = git \1/' | \
+      sed 's/ = !/ = /' | \
+      ${_alias_tips__PLUGIN_DIR}/alias-tips $* && \
+      return
+  fi
+
   alias | ${_alias_tips__PLUGIN_DIR}/alias-tips $*
 }
 


### PR DESCRIPTION
It works by rewriting the output of `git alias` to a compatible `alias` (Zsh built-in) output:

`last = log -1 HEAD` => `git last = git log -1 HEAD`
`authors = !git shortlog -s -- | sort -n -k1` => `git authors = git shortlog -s -- | sort -n -k1`

Not very extensively tested yet.

- [ ] Add tests
- [ ] Update documentation

Closes #12.