### PR TITLE
Properly get location of script directory

### DIFF
--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -1,4 +1,4 @@
-_alias_tips__PLUGIN_DIR=$(dirname $0)
+_alias_tips__PLUGIN_DIR=${0:a:h}
 
 #export ZSH_PLUGINS_ALIAS_TIPS_TEXT="💡 Alias tip: "
 #export ZSH_PLUGINS_ALIAS_TIPS_EXCLUDES="_ c"


### PR DESCRIPTION
Source: http://unix.stackexchange.com/a/115431

Fixes issue mentioned in #6.

PS: I saw this while testing this from `/tmp/alias-tips` and I had sourced it as `./alias-tips.plugin.zsh` in that directory.

NOTE: I didn't test this yet...