### PR TITLE
Only forward function name/header

### DIFF
--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -18,7 +18,7 @@ _alias_tips__preexec () {
 
   shell_aliases=$(alias)
 
-  shell_functions=$(functions)
+  shell_functions=$(functions | grep '^[^'$'\t'' _-].\+ () {$')
 
   echo $shell_functions "\n" $git_aliases "\n" $shell_aliases | \
     python ${_alias_tips__PLUGIN_DIR}/alias-tips.py $*

--- a/alias-tips.py
+++ b/alias-tips.py
@@ -17,13 +17,7 @@ def split(input):
         line = line.strip('\n')
         if line.endswith(' () {'):
             functions.append(line[:-5].strip())
-        elif '=' in line and not ( \
-                line.startswith('\t') or \
-                line.startswith(' ') or \
-                line.startswith('"') or \
-                line.startswith("'") or \
-                line.startswith('}') or \
-                line.startswith('EOF')):
+        elif '=' in line:
             # It's hard to exclude all accidental lines in function body without
             # parsing it. This is "good enough"(tm)
             aliases.append(line)


### PR DESCRIPTION
Filter out function body to reduce the amount of lines to process in the
main Python script.
Closes #26.