### PR TITLE
Removed unnecessary sort and output of same length alias

### DIFF
--- a/alias-tips.py
+++ b/alias-tips.py
@@ -64,7 +64,6 @@ def expand_input(input, aliases):
 
 
 def find_alias(aliases, input):
-    aliases.sort()
     aliases.sort(key=lambda x: len(x[1]), reverse=True)
 
     res_prev, res = None, input

--- a/alias-tips.py
+++ b/alias-tips.py
@@ -103,7 +103,7 @@ def main(args):
     aliases  = parse_aliases(als)
     alias    = run(aliases, input, expand, excludes)
 
-    if alias != input:
+    if len(alias) < len(input) and alias != input:
         print(format_tip(alias, prefix))
     else:
         sys.exit(1)

--- a/test_alias-tips.py
+++ b/test_alias-tips.py
@@ -140,6 +140,9 @@ class TestBlackbox(TestCase):
         self.assertEqual(run_blackboxed('f', 'f=bar\nb=baz'), b'')
         self.assertEqual(run_blackboxed('b', 'f=bar\nb=baz'), b'')
 
+    def test_no_same_length(self):
+        self.assertEqual(run_blackboxed('ls','ls=ls'), b'')
+
     def test_multiple(self):
         os.putenv('ZSH_PLUGINS_ALIAS_TIPS_TEXT', '')
         self.assertEqual(run_blackboxed('git status -sb', 'g=\'git\'\ngit st = git status -sb'), b'\x1b[94m\x1b[1;94mg st\x1b[0m\n')


### PR DESCRIPTION
Removed unnecessary sort of aliases 
Removed output of same length alias, eg. sl for ls (typo fix aliases)