### PR TITLE
Find actual location of _alias_tips__PLUGIN_DIR if sourced from a symlink

### DIFF
--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -1,5 +1,12 @@
 _alias_tips__PLUGIN_DIR=${0:a:h}
 
+# If alias-tips is loaded from a symlink, then work out
+# where the actual file is located
+if [[ -L ${0:a} ]]; then
+  _alias_tips__PLUGIN_DIR=$(readlink ${0:a})
+  _alias_tips__PLUGIN_DIR=${_alias_tips__PLUGIN_DIR:h}
+fi
+
 #export ZSH_PLUGINS_ALIAS_TIPS_TEXT="💡 Alias tip: "
 #export ZSH_PLUGINS_ALIAS_TIPS_EXCLUDES="_ c"
 #export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=0


### PR DESCRIPTION
If `alias-tips.plugin.zsh` is sourced from a symlink (as when used with my [zulu](https://github.com/zulu-zsh/zulu) plugin manager) it fails to find `alias-tips.py` as it's in a different directory. This fix corrects that by detecting if the script is a symlink when it's sourced, and updating the `$_alias_tips__PLUGIN_DIR` variable accordingly.