### PR TITLE
Simplify regex for shell_functions.

### DIFF
--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -25,7 +25,7 @@ _alias_tips__preexec () {
 
   shell_aliases=$(alias)
 
-  shell_functions=$(functions | grep '^[^'$'\t'' _-].\+ () {$')
+  shell_functions=$(functions | grep '^[a-zA-Z].\+ () {$')
 
   echo $shell_functions "\n" $git_aliases "\n" $shell_aliases | \
     python ${_alias_tips__PLUGIN_DIR}/alias-tips.py $*


### PR DESCRIPTION
Additionally, this prevents `_alias_tips__preexec` from getting called
twice which saves about 100ms on startup.  I'm not sure why it has this
effect, but I suspect it has something to do with quoting and the dollar
sign in the original regex.

Here's the zprof info from config before this commit:

|          | Calls |  Total |   Each |
|----------|-------|--------|--------|
| Original |     2 | 215.33 | 107.67 |
| New      |     1 | 108.31 | 108.31 |