### PR TITLE
Add option to abort when alias can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=0
 ```
 
 
+### Force Alias Use
+
+If you want to force yourself to use the aliases you set you can enable this
+option through this environmental variable:
+
+```
+:
+export ZSH_PLUGINS_ALIAS_TIPS_FORCE=1
+:
+```
+
+This will make alias-tips to abort the command you have entered if there exists
+an alias for it.
+
+
 # Limitations
 
 - *Suffix* and *Global* aliases are currently not supported. Only *Prefix*

--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -29,6 +29,8 @@ _alias_tips__preexec () {
 
   echo $shell_functions "\n" $git_aliases "\n" $shell_aliases | \
     python ${_alias_tips__PLUGIN_DIR}/alias-tips.py $*
+  ret=$?
+  if [[ $ret = 10 ]]; then exit 10; fi
 }
 
 autoload -Uz add-zsh-hook

--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -27,10 +27,12 @@ _alias_tips__preexec () {
 
   shell_functions=$(functions | grep '^[a-zA-Z].\+ () {$')
 
+  # Exit code returned from python script when we want to force use of aliases.
+  local force_exit_code=10
   echo $shell_functions "\n" $git_aliases "\n" $shell_aliases | \
     python ${_alias_tips__PLUGIN_DIR}/alias-tips.py $*
   ret=$?
-  if [[ $ret = 10 ]]; then exit 10; fi
+  if [[ $ret = $force_exit_code ]]; then exit $force_exit_code; fi
 }
 
 autoload -Uz add-zsh-hook

--- a/alias-tips.py
+++ b/alias-tips.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 import os
 import sys
 
+FORCE_EXIT_CODE = 10
+
 
 def format_tip(s, prefix):
     color_blue_normal = '\033[94m'
@@ -107,7 +109,7 @@ def main(args):
     if len(alias) < len(input) and alias != input:
         print(format_tip(alias, prefix))
         if force:
-            sys.exit(10)
+            sys.exit(FORCE_EXIT_CODE)
     else:
         sys.exit(1)
 

--- a/alias-tips.py
+++ b/alias-tips.py
@@ -92,6 +92,7 @@ def main(args):
     prefix   = os.getenv('ZSH_PLUGINS_ALIAS_TIPS_TEXT', 'Alias tip: ')
     expand   = os.getenv('ZSH_PLUGINS_ALIAS_TIPS_EXPAND', '1') == '1'
     excludes = os.getenv('ZSH_PLUGINS_ALIAS_TIPS_EXCLUDES', '')
+    force    = os.getenv('ZSH_PLUGINS_ALIAS_TIPS_FORCE', '0') == '1'
     input    = args[0].strip()  # Other args are resolved aliases
     als, fns = split(sys.stdin.readlines())
 
@@ -105,6 +106,8 @@ def main(args):
 
     if len(alias) < len(input) and alias != input:
         print(format_tip(alias, prefix))
+        if force:
+            sys.exit(10)
     else:
         sys.exit(1)
 


### PR DESCRIPTION
Closes #34

Example implementation.
I picked `10` as a return code randomly.
Enabled if `$ZSH_PLUGINS_ALIAS_TIPS_FORCE` is `1`.