### PR TITLE
Add option to reveal aliased command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Alias tip: g st
     ```
 
 
+## zplug
+
+1. Add `zplug "djui/alias-tips"` to your `.zshrc`
+2. Install it with `zplug install`
+
+
 ## antigen
 
 1. Add `antigen bundle djui/alias-tips` to your `.zshrc` with your other antigen
@@ -162,7 +168,7 @@ export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=0
 If you want to force yourself to use the aliases you set you can enable this
 option through this environmental variable:
 
-```
+```sh
 :
 export ZSH_PLUGINS_ALIAS_TIPS_FORCE=1
 :
@@ -170,6 +176,35 @@ export ZSH_PLUGINS_ALIAS_TIPS_FORCE=1
 
 This will cause alias-tips to abort the command you have entered if there exists
 an alias for it.
+
+
+### Reveal Command
+
+If you want to reveal aliased command, e.g. to demonstrate your shell to someone else
+you can enable this option through this environmental variable:
+
+```sh
+:
+export ZSH_PLUGINS_ALIAS_TIPS_REVEAL=1
+:
+```
+
+Use this environmental variable to customize text:
+
+``````sh
+:
+export ZSH_PLUGINS_ALIAS_TIPS_REVEAL_TEXT="Alias tip: "
+:
+``````
+
+And this to exclude some obvious expansions:
+
+``````sh
+:
+export ZSH_PLUGINS_ALIAS_TIPS_REVEAL_EXCLUDES=(_ ll vi)
+:
+``````
+
 
 
 # Limitations

--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -12,6 +12,19 @@ fi
 #export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=0
 
 _alias_tips__preexec () {
+  if [[ $1 != $2 ]] then # Alias is used
+    if [[ ${ZSH_PLUGINS_ALIAS_TIPS_REVEAL-0} == 1 ]] then # Reveal aliased command
+      if [[ ${${ZSH_PLUGINS_ALIAS_TIPS_REVEAL_EXCLUDES-()}[(I)$1]} != 0 ]] then # Exit
+        return 0
+      fi
+      local reveal_text=${ZSH_PLUGINS_ALIAS_TIPS_REVEAL_TEXT-${ZSH_PLUGINS_ALIAS_TIPS_TEXT-Alias tip: }}
+      local color_dark_gray='\e[1;30m'
+      local color_reset='\e[0m'
+      echo -e "$color_dark_gray$reveal_text$2 $color_reset"
+    fi
+    return 0
+  fi
+
   if hash git 2> /dev/null; then
 
     # alias.foo bar      => git foo = git bar

--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -12,17 +12,19 @@ fi
 #export ZSH_PLUGINS_ALIAS_TIPS_EXPAND=0
 
 _alias_tips__preexec () {
-  if [[ $1 != $2 ]] then # Alias is used
-    if [[ ${ZSH_PLUGINS_ALIAS_TIPS_REVEAL-0} == 1 ]] then # Reveal aliased command
-      if [[ ${${ZSH_PLUGINS_ALIAS_TIPS_REVEAL_EXCLUDES-()}[(I)$1]} != 0 ]] then # Exit
-        return 0
-      fi
-      local reveal_text=${ZSH_PLUGINS_ALIAS_TIPS_REVEAL_TEXT-${ZSH_PLUGINS_ALIAS_TIPS_TEXT-Alias tip: }}
-      local color_dark_gray='\e[1;30m'
-      local color_reset='\e[0m'
-      echo -e "$color_dark_gray$reveal_text$2 $color_reset"
+  local CMD=$1
+  local CMD_EXPANDED=$2
+  if [[ $CMD != $CMD_EXPANDED ]] then # Alias is used
+    if [[ ${ZSH_PLUGINS_ALIAS_TIPS_REVEAL-0} == 1 ]] \
+    && [[ ${${ZSH_PLUGINS_ALIAS_TIPS_REVEAL_EXCLUDES-()}[(I)$1]} == 0 ]] then # Reveal cmd
+        local reveal_text=${ZSH_PLUGINS_ALIAS_TIPS_REVEAL_TEXT-Alias for: }
+        local color_dark_gray='\e[1;30m'
+        local color_reset='\e[0m'
+        echo -e "$color_dark_gray$reveal_text$CMD_EXPANDED $color_reset"
     fi
-    return 0
+    if [[ ${ZSH_PLUGINS_ALIAS_TIPS_EXPAND-1} == 0 ]] then
+      return 0
+    fi
   fi
 
   if hash git 2> /dev/null; then


### PR DESCRIPTION
The final result is demonstrated at the following gif:
![]( https://camo.githubusercontent.com/c04e3cf3358bad01c1c7a66c3cc3cdcacf08499a/68747470733a2f2f692e696d6775722e636f6d2f6959446c59706a2e676966)

In addition some README tweaks are included.

Early return  added to `_alias_tips__preexec` to avoid unnecessary computation when alias is invoked and no need to expand it further