### PR TITLE
Port to Python 3

### DIFF
--- a/alias-tips.plugin.zsh
+++ b/alias-tips.plugin.zsh
@@ -48,7 +48,7 @@ _alias_tips__preexec () {
   # Exit code returned from python script when we want to force use of aliases.
   local force_exit_code=10
   echo $shell_functions "\n" $git_aliases "\n" $shell_aliases | \
-    python ${_alias_tips__PLUGIN_DIR}/alias-tips.py $*
+    python3 ${_alias_tips__PLUGIN_DIR}/alias-tips.py $*
   local ret=$?
   if [[ $ret = $force_exit_code ]]; then kill -s INT $$ ; fi
 }

--- a/alias-tips.py
+++ b/alias-tips.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 


### PR DESCRIPTION
Modern Ubuntu versions, like 21.04 don't include Python 2 executable by default, only Python 3.
As Python 2 is officially EOL, I propose porting alias tips to Python 3