### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Alias tip: g st
     ```
 
 
+## Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `alias-tips` in just one click.
+
+<a href="https://fig.io/plugins/other/alias-tips_djui" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
+
 ## zplug
 
 1. Add `zplug "djui/alias-tips"` to your `.zshrc`


### PR DESCRIPTION
We recently listed alias-tips on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme. We have over 100k users that will benefit from this. 

Thanks so much and please let me know if you have any questions!

