### PR TITLE
Especificando local para clonar o repositório

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Install `alias-tips` in just one click.
 
 ## Zsh
 
-1. Get it `git clone https://github.com/djui/alias-tips.git`
+1. 1. Get it `git clone https://github.com/djui/alias-tips.git ~/.zsh/alias-tips`
 2. Add `source alias-tips/alias-tips.plugin.zsh` to your `.zshrc`.
 
 


### PR DESCRIPTION
Na instalação para o ZSH não é especificado o local de clonagem do repositório, como deveria ser feito adicionando um segundo argumento `~/.zsh/alias-tips`.